### PR TITLE
fix: keep the logic of the RemoveZeroHex and DecodeHexString methods consistent and add performance testing.

### DIFF
--- a/util/hex.go
+++ b/util/hex.go
@@ -7,8 +7,10 @@ import (
 
 // delete the 0x from the front
 func RemoveZeroHex(s string) []byte {
-	if strings.HasPrefix(s, "0x") || strings.HasPrefix(s, "0X") {
-		s = s[2:]
+	if len(s) > 1 {
+		if s[0:2] == "0x" || s[0:2] == "0X" {
+			s = s[2:]
+		}
 	}
 	if len(s)%2 == 1 {
 		s = "0" + s
@@ -30,6 +32,23 @@ func EncodeHexWith0x(bytes []byte) string {
 }
 
 func DecodeHexString(hexString string) ([]byte, error) {
+	if len(hexString) >= 2 {
+		if hexString[0:2] == "0x" || hexString[0:2] == "0X" {
+			hexString = hexString[2:]
+		}
+	}
+	if len(hexString)%2 != 0 {
+		hexString = "0" + hexString
+	}
+	return hex.DecodeString(hexString)
+}
+
+func DecodeHexStringBackup(hexString string) ([]byte, error) {
+	if len(hexString) >= 2 {
+		if hexString[0:2] == "0x" || hexString[0:2] == "0X" {
+			hexString = hexString[2:]
+		}
+	}
 	if strings.HasPrefix(hexString, "0x") || strings.HasPrefix(hexString, "0X") {
 		hexString = hexString[2:]
 	}

--- a/util/hex.go
+++ b/util/hex.go
@@ -7,10 +7,8 @@ import (
 
 // delete the 0x from the front
 func RemoveZeroHex(s string) []byte {
-	if len(s) > 1 {
-		if s[0:2] == "0x" || s[0:2] == "0X" {
-			s = s[2:]
-		}
+	if strings.HasPrefix(s, "0x") || strings.HasPrefix(s, "0X") {
+		s = s[2:]
 	}
 	if len(s)%2 == 1 {
 		s = "0" + s

--- a/util/hex_test.go
+++ b/util/hex_test.go
@@ -19,3 +19,57 @@ func TestDecodeHexString2(t *testing.T) {
 	}
 	t.Log(bytes)
 }
+
+func BenchmarkDecodeHexStringWithout0x(b *testing.B) {
+	for i := 0; i < b.N; i++ {
+		bytes, err := DecodeHexString("e33ef3d7883cd3f6b9c2a72b916c36066cca8443c718fb53bc0a0607de9e4d9a")
+		if err != nil {
+			b.Fatal(err)
+		}
+		b.Log(bytes)
+	}
+}
+
+func BenchmarkDecodeHexStringWith0x(b *testing.B) {
+	for i := 0; i < b.N; i++ {
+		bytes, err := DecodeHexString("0xe33ef3d7883cd3f6b9c2a72b916c36066cca8443c718fb53bc0a0607de9e4d9a")
+		if err != nil {
+			b.Fatal(err)
+		}
+		b.Log(bytes)
+	}
+}
+
+func BenchmarkDecodeHexStringBackupWithout0x(b *testing.B) {
+	for i := 0; i < b.N; i++ {
+		bytes, err := DecodeHexStringBackup("e33ef3d7883cd3f6b9c2a72b916c36066cca8443c718fb53bc0a0607de9e4d9a")
+		if err != nil {
+			b.Fatal(err)
+		}
+		b.Log(bytes)
+	}
+}
+
+func BenchmarkDecodeHexStringBackupWith0x(b *testing.B) {
+	for i := 0; i < b.N; i++ {
+		bytes, err := DecodeHexStringBackup("0xe33ef3d7883cd3f6b9c2a72b916c36066cca8443c718fb53bc0a0607de9e4d9a")
+		if err != nil {
+			b.Fatal(err)
+		}
+		b.Log(bytes)
+	}
+}
+
+func BenchmarkRemoveZeroHexWithout0x(b *testing.B) {
+	for i := 0; i < b.N; i++ {
+		bytes := RemoveZeroHex("e33ef3d7883cd3f6b9c2a72b916c36066cca8443c718fb53bc0a0607de9e4d9a")
+		b.Log(bytes)
+	}
+}
+
+func BenchmarkRemoveZeroHexWith0x(b *testing.B) {
+	for i := 0; i < b.N; i++ {
+		bytes := RemoveZeroHex("0xe33ef3d7883cd3f6b9c2a72b916c36066cca8443c718fb53bc0a0607de9e4d9a")
+		b.Log(bytes)
+	}
+}


### PR DESCRIPTION
`
without0x
BenchmarkDecodeHexString-10    	  176349	      5912 ns/op
with0x
BenchmarkDecodeHexString-10    	  152390	      6741 ns/op
without0x
BenchmarkDecodeHexStringBackupWithout0x-10    	  189400	      5731 ns/op
with0x
BenchmarkDecodeHexStringBackupWith0x-10    	  173818	      6307 ns/op`
`
I have a question. Why write two methods with the same functionality, but one of them doesn't perform error handling?