### PR TITLE
update btcec to v2.3.4

### DIFF
--- a/coins/avax/avax.go
+++ b/coins/avax/avax.go
@@ -4,12 +4,13 @@ import (
 	"crypto/sha256"
 	"encoding/hex"
 	"errors"
+	"strings"
+
 	"github.com/btcsuite/btcd/btcec/v2"
 	"github.com/btcsuite/btcd/btcec/v2/ecdsa"
 	"github.com/btcsuite/btcd/btcutil"
 	"github.com/btcsuite/btcd/btcutil/bech32"
 	"github.com/okx/go-wallet-sdk/crypto/base58"
-	"strings"
 )
 
 func NewAddress(chainId string, hrp string, publicKey *btcec.PublicKey) (string, error) {
@@ -67,10 +68,7 @@ func NewTransferTransaction(netWorkId uint32, blockchainId string, inputs *[]Tra
 			return "", err
 		}
 		privateKey, _ := btcec.PrivKeyFromBytes(pk)
-		sig2, err := ecdsa.SignCompact(privateKey, hash[:], false)
-		if err != nil {
-			return "", err
-		}
+		sig2 := ecdsa.SignCompact(privateKey, hash[:], false)
 		sig := make([]byte, len(sig2))
 		copy(sig, sig2[1:])
 		sig[64] = sig2[0] - 27

--- a/coins/avax/go.mod
+++ b/coins/avax/go.mod
@@ -3,7 +3,7 @@ module github.com/okx/go-wallet-sdk/coins/avax
 go 1.19
 
 require (
-	github.com/btcsuite/btcd/btcec/v2 v2.3.2
+	github.com/btcsuite/btcd/btcec/v2 v2.3.4
 	github.com/btcsuite/btcd/btcutil v1.1.3
 	github.com/okx/go-wallet-sdk/crypto v0.0.1
 	github.com/stretchr/testify v1.8.4
@@ -14,7 +14,7 @@ require (
 	github.com/btcsuite/btcd/chaincfg/chainhash v1.0.1 // indirect
 	github.com/btcsuite/btcutil v1.0.2 // indirect
 	github.com/davecgh/go-spew v1.1.1 // indirect
-	github.com/decred/dcrd/dcrec/secp256k1/v4 v4.0.1 // indirect
+	github.com/decred/dcrd/dcrec/secp256k1/v4 v4.3.0 // indirect
 	github.com/pmezard/go-difflib v1.0.0 // indirect
 	golang.org/x/crypto v0.12.0 // indirect
 	golang.org/x/sys v0.11.0 // indirect

--- a/coins/bitcoin/go.mod
+++ b/coins/bitcoin/go.mod
@@ -4,7 +4,7 @@ go 1.19
 
 require (
 	github.com/btcsuite/btcd v0.23.4
-	github.com/btcsuite/btcd/btcec/v2 v2.3.2
+	github.com/btcsuite/btcd/btcec/v2 v2.3.4
 	github.com/btcsuite/btcd/btcutil v1.1.3
 	github.com/btcsuite/btcd/btcutil/psbt v1.1.8
 	github.com/btcsuite/btcd/chaincfg/chainhash v1.0.2
@@ -22,8 +22,8 @@ require (
 	github.com/consensys/gnark-crypto v0.12.1 // indirect
 	github.com/crate-crypto/go-kzg-4844 v0.3.0 // indirect
 	github.com/davecgh/go-spew v1.1.1 // indirect
-	github.com/decred/dcrd/crypto/blake256 v1.0.0 // indirect
-	github.com/decred/dcrd/dcrec/secp256k1/v4 v4.0.1 // indirect
+	github.com/decred/dcrd/crypto/blake256 v1.0.1 // indirect
+	github.com/decred/dcrd/dcrec/secp256k1/v4 v4.3.0 // indirect
 	github.com/ethereum/c-kzg-4844 v0.3.1 // indirect
 	github.com/go-stack/stack v1.8.1 // indirect
 	github.com/holiman/uint256 v1.2.3 // indirect

--- a/coins/bitcoin/message.go
+++ b/coins/bitcoin/message.go
@@ -7,6 +7,10 @@ import (
 	"encoding/hex"
 	"errors"
 	"fmt"
+	"io"
+	"math/big"
+	"reflect"
+
 	"github.com/btcsuite/btcd/btcec/v2"
 	"github.com/btcsuite/btcd/btcec/v2/ecdsa"
 	"github.com/btcsuite/btcd/btcec/v2/schnorr"
@@ -17,9 +21,6 @@ import (
 	"github.com/btcsuite/btcd/txscript"
 	"github.com/btcsuite/btcd/wire"
 	"github.com/okx/go-wallet-sdk/crypto"
-	"io"
-	"math/big"
-	"reflect"
 )
 
 const (
@@ -534,7 +535,7 @@ func SignMessage(wif string, prefix, message string) (string, error) {
 	if err != nil {
 		return "", err
 	}
-	sig, err := ecdsa.SignCompact(w.PrivKey, messageHash, true)
+	sig := ecdsa.SignCompact(w.PrivKey, messageHash, true)
 	if err != nil {
 		return "", err
 	}

--- a/coins/cosmos/atom/atom.go
+++ b/coins/cosmos/atom/atom.go
@@ -4,13 +4,14 @@ import (
 	"crypto/sha256"
 	"encoding/base64"
 	"encoding/hex"
+	"math/big"
+
 	"github.com/btcsuite/btcd/btcec/v2"
 	"github.com/btcsuite/btcd/btcec/v2/ecdsa"
 	"github.com/btcsuite/btcd/btcutil"
 	"github.com/btcsuite/btcd/btcutil/bech32"
 	"github.com/okx/go-wallet-sdk/coins/cosmos/tx"
 	"github.com/okx/go-wallet-sdk/coins/cosmos/types"
-	"math/big"
 )
 
 const (
@@ -89,10 +90,7 @@ func Sign(rawHex string, privateKey *btcec.PrivateKey) (string, error) {
 		return "", err
 	}
 	hash := sha256.Sum256(signDocBytes)
-	signature, err := ecdsa.SignCompact(privateKey, hash[:], false)
-	if err != nil {
-		return "", err
-	}
+	signature := ecdsa.SignCompact(privateKey, hash[:], false)
 	return hex.EncodeToString(signature[1:]), nil
 }
 

--- a/coins/cosmos/cosmos.go
+++ b/coins/cosmos/cosmos.go
@@ -7,6 +7,10 @@ import (
 	"encoding/json"
 	"errors"
 	"fmt"
+	"math/big"
+	"sort"
+	"strconv"
+
 	"github.com/btcsuite/btcd/btcec/v2"
 	"github.com/btcsuite/btcd/btcec/v2/ecdsa"
 	"github.com/btcsuite/btcd/btcutil"
@@ -17,9 +21,6 @@ import (
 	"github.com/okx/go-wallet-sdk/coins/cosmos/types/ethsecp256k1"
 	"github.com/okx/go-wallet-sdk/coins/cosmos/types/ibc"
 	"golang.org/x/crypto/sha3"
-	"math/big"
-	"sort"
-	"strconv"
 )
 
 const (
@@ -259,10 +260,7 @@ func SignRawTransaction(signDoc string, privateKey *btcec.PrivateKey) (string, e
 		return "", err
 	}
 	hash := sha256.Sum256(signDocBtyes)
-	signature, err := ecdsa.SignCompact(privateKey, hash[:], false)
-	if err != nil {
-		return "", err
-	}
+	signature := ecdsa.SignCompact(privateKey, hash[:], false)
 	return hex.EncodeToString(signature[1:]), nil
 }
 
@@ -400,10 +398,7 @@ func BuildTxAction(param CommonParam, messages []*types.Any, privateKeyHex strin
 	var signBytes []byte
 	if useEthSecp256k1 {
 		m := HashMessage(signDocBtyes)
-		result, err := ecdsa.SignCompact(privateKey, m, false)
-		if err != nil {
-			return "", err
-		}
+		result := ecdsa.SignCompact(privateKey, m, false)
 		V := result[0]
 		R := result[1:33]
 		S := result[33:65]
@@ -413,11 +408,7 @@ func BuildTxAction(param CommonParam, messages []*types.Any, privateKeyHex strin
 		signBytes = append(signBytes, V-27)
 	} else {
 		hash := sha256.Sum256(signDocBtyes)
-		var err error
-		signBytes, err = ecdsa.SignCompact(privateKey, hash[:], false)
-		if err != nil {
-			return "", err
-		}
+		signBytes = ecdsa.SignCompact(privateKey, hash[:], false)
 		signBytes = signBytes[1:]
 	}
 
@@ -471,10 +462,7 @@ func BuildTxActionForSignMessage(param CommonParam, messages []*types.Any, priva
 	var signBytes []byte
 	if useEthSecp256k1 {
 		m := HashMessage(signDocBtyes)
-		result, err := ecdsa.SignCompact(privateKey, m, false)
-		if err != nil {
-			return "", "", err
-		}
+		result := ecdsa.SignCompact(privateKey, m, false)
 		V := result[0]
 		R := result[1:33]
 		S := result[33:65]
@@ -484,11 +472,7 @@ func BuildTxActionForSignMessage(param CommonParam, messages []*types.Any, priva
 		signBytes = append(signBytes, V-27)
 	} else {
 		hash := sha256.Sum256(signDocBtyes)
-		var err error
-		signBytes, err = ecdsa.SignCompact(privateKey, hash[:], false)
-		if err != nil {
-			return "", "", err
-		}
+		signBytes = ecdsa.SignCompact(privateKey, hash[:], false)
 		signBytes = signBytes[1:]
 	}
 
@@ -544,10 +528,7 @@ func SignDoc(body string, auth string, privateKeyHex string, ChainId string, Acc
 
 	var signBytes []byte
 	hash := sha256.Sum256(signDocBtyes)
-	signature, err := ecdsa.SignCompact(privateKey, hash[:], false)
-	if err != nil {
-		return "", "", err
-	}
+	signature := ecdsa.SignCompact(privateKey, hash[:], false)
 	signBytes = signature[1:]
 
 	signatures := make([][]byte, 0)
@@ -601,10 +582,7 @@ func SignAminoMessage(data string, privateKeyHex string) (string, error) {
 	}
 
 	privateKey, _ := btcec.PrivKeyFromBytes(pkBytes)
-	signature, err := ecdsa.SignCompact(privateKey, hash[:], false)
-	if err != nil {
-		return "", err
-	}
+	signature := ecdsa.SignCompact(privateKey, hash[:], false)
 	return base64.StdEncoding.EncodeToString(signature[1:]), nil
 }
 
@@ -836,9 +814,6 @@ func GetSigningHash(rawTxByte string) (string, error) {
 }
 func SignRawJsonTransaction(signDoc string, privateKey *btcec.PrivateKey) (string, error) {
 	hash := sha256.Sum256([]byte(signDoc))
-	signature, err := ecdsa.SignCompact(privateKey, hash[:], false)
-	if err != nil {
-		return "", err
-	}
+	signature := ecdsa.SignCompact(privateKey, hash[:], false)
 	return hex.EncodeToString(signature[1:]), nil
 }

--- a/coins/cosmos/go.mod
+++ b/coins/cosmos/go.mod
@@ -4,7 +4,7 @@ go 1.19
 
 require (
 	cosmossdk.io/math v1.1.2
-	github.com/btcsuite/btcd/btcec/v2 v2.3.2
+	github.com/btcsuite/btcd/btcec/v2 v2.3.4
 	github.com/btcsuite/btcd/btcutil v1.1.3
 	github.com/ethereum/go-ethereum v1.12.2
 	github.com/okx/go-wallet-sdk/crypto v0.0.1
@@ -19,7 +19,7 @@ require (
 	github.com/btcsuite/btcd v0.23.0 // indirect
 	github.com/btcsuite/btcd/chaincfg/chainhash v1.0.1 // indirect
 	github.com/davecgh/go-spew v1.1.1 // indirect
-	github.com/decred/dcrd/dcrec/secp256k1/v4 v4.0.1 // indirect
+	github.com/decred/dcrd/dcrec/secp256k1/v4 v4.3.0 // indirect
 	github.com/pmezard/go-difflib v1.0.0 // indirect
 	github.com/tyler-smith/go-bip32 v1.0.0 // indirect
 	golang.org/x/exp v0.0.0-20230810033253-352e893a4cad // indirect

--- a/coins/cosmos/okc/tx/client.go
+++ b/coins/cosmos/okc/tx/client.go
@@ -4,6 +4,7 @@ import (
 	"encoding/base64"
 	"encoding/hex"
 	"errors"
+
 	"github.com/btcsuite/btcd/btcec/v2"
 	"github.com/btcsuite/btcd/btcec/v2/ecdsa"
 	"github.com/okx/go-wallet-sdk/coins/cosmos/okc/tx/amino"
@@ -30,10 +31,7 @@ func MakeSignature(privateKeyHex string, msg authtypes.StdSignMsg) (sig authtype
 	}
 	ecPriv, ecPub := btcec.PrivKeyFromBytes(pkBytes)
 
-	result, err := ecdsa.SignCompact(ecPriv, m, false)
-	if err != nil {
-		return
-	}
+	result := ecdsa.SignCompact(ecPriv, m, false)
 
 	V := result[0]
 	R := result[1:33]

--- a/coins/cosmos/terra/terra.go
+++ b/coins/cosmos/terra/terra.go
@@ -4,13 +4,14 @@ import (
 	"crypto/sha256"
 	"encoding/base64"
 	"encoding/hex"
+	"math/big"
+
 	"github.com/btcsuite/btcd/btcec/v2"
 	"github.com/btcsuite/btcd/btcec/v2/ecdsa"
 	"github.com/btcsuite/btcd/btcutil/bech32"
 	"github.com/okx/go-wallet-sdk/coins/cosmos/tx"
 	"github.com/okx/go-wallet-sdk/coins/cosmos/types"
 	"golang.org/x/crypto/ripemd160"
-	"math/big"
 )
 
 type TransactionInput struct {
@@ -176,10 +177,7 @@ func Sign(rawHex string, privateKeyHex string) string {
 
 	signDocBtyes, _ := hex.DecodeString(rawHex)
 	hash := sha256.Sum256(signDocBtyes)
-	b, err := ecdsa.SignCompact(privateKey, hash[:], false)
-	if err != nil {
-		return ""
-	}
+	b := ecdsa.SignCompact(privateKey, hash[:], false)
 	return hex.EncodeToString(b[1:])
 }
 

--- a/coins/ethereum/eth.go
+++ b/coins/ethereum/eth.go
@@ -4,8 +4,9 @@ import (
 	"encoding/hex"
 	"errors"
 	"fmt"
-	"github.com/btcsuite/btcd/btcec/v2"
 	"math/big"
+
+	"github.com/btcsuite/btcd/btcec/v2"
 
 	"github.com/btcsuite/btcd/btcec/v2/ecdsa"
 	"github.com/ethereum/go-ethereum/rlp"
@@ -174,10 +175,7 @@ func NewTransactionFromRaw(raw string) (*EthTransaction, error) {
 }
 
 func SignAsRecoverable(value []byte, prvKey *btcec.PrivateKey) (*SignatureData, error) {
-	sig, err := ecdsa.SignCompact(prvKey, value, false)
-	if err != nil {
-		return nil, err
-	}
+	sig := ecdsa.SignCompact(prvKey, value, false)
 	V := sig[0]
 	R := sig[1:33]
 	S := sig[33:65]

--- a/coins/ethereum/go.mod
+++ b/coins/ethereum/go.mod
@@ -3,7 +3,7 @@ module github.com/okx/go-wallet-sdk/coins/ethereum
 go 1.19
 
 require (
-	github.com/btcsuite/btcd/btcec/v2 v2.3.2
+	github.com/btcsuite/btcd/btcec/v2 v2.3.4
 	github.com/ethereum/go-ethereum v1.12.2
 	github.com/okx/go-wallet-sdk/crypto v0.0.1
 	github.com/okx/go-wallet-sdk/util v0.0.1
@@ -13,7 +13,7 @@ require (
 
 require (
 	github.com/davecgh/go-spew v1.1.1 // indirect
-	github.com/decred/dcrd/dcrec/secp256k1/v4 v4.0.1 // indirect
+	github.com/decred/dcrd/dcrec/secp256k1/v4 v4.3.0 // indirect
 	github.com/go-stack/stack v1.8.1 // indirect
 	github.com/holiman/uint256 v1.2.3 // indirect
 	github.com/pmezard/go-difflib v1.0.0 // indirect

--- a/coins/filecoin/account.go
+++ b/coins/filecoin/account.go
@@ -10,14 +10,15 @@ import (
 	"encoding/hex"
 	"errors"
 	"fmt"
+	"math/bits"
+	"strconv"
+	"strings"
+
 	"github.com/btcsuite/btcd/btcec/v2"
 	ecdsa2 "github.com/btcsuite/btcd/btcec/v2/ecdsa"
 	"github.com/dchest/blake2b"
 	"github.com/decred/dcrd/dcrec/secp256k1/v4"
 	"github.com/okx/go-wallet-sdk/util"
-	"math/bits"
-	"strconv"
-	"strings"
 )
 
 var (
@@ -163,10 +164,7 @@ func SignTx(message *Message, privateKeyHex string) (*SignedMessage, error) {
 	}
 	privateKey, _ := btcec.PrivKeyFromBytes(privKeyBytes)
 
-	sig, err := ecdsa2.SignCompact(privateKey, message.Hash(), false)
-	if err != nil {
-		return nil, err
-	}
+	sig := ecdsa2.SignCompact(privateKey, message.Hash(), false)
 	V := sig[0]
 	R := sig[1:33]
 	S := sig[33:65]

--- a/coins/filecoin/go.mod
+++ b/coins/filecoin/go.mod
@@ -3,9 +3,9 @@ module github.com/okx/go-wallet-sdk/coins/filecoin
 go 1.19
 
 require (
-	github.com/btcsuite/btcd/btcec/v2 v2.3.2
+	github.com/btcsuite/btcd/btcec/v2 v2.3.4
 	github.com/dchest/blake2b v1.0.0
-	github.com/decred/dcrd/dcrec/secp256k1/v4 v4.2.0
+	github.com/decred/dcrd/dcrec/secp256k1/v4 v4.3.0
 	github.com/fxamacker/cbor v1.5.1
 	github.com/okx/go-wallet-sdk/util v0.0.1
 	github.com/stretchr/testify v1.8.4

--- a/coins/flow/go.mod
+++ b/coins/flow/go.mod
@@ -3,7 +3,7 @@ module github.com/okx/go-wallet-sdk/coins/flow
 go 1.19
 
 require (
-	github.com/btcsuite/btcd/btcec/v2 v2.3.2
+	github.com/btcsuite/btcd/btcec/v2 v2.3.4
 	github.com/ethereum/go-ethereum v1.12.2
 	github.com/stretchr/testify v1.8.4
 	golang.org/x/crypto v0.14.0
@@ -11,7 +11,7 @@ require (
 
 require (
 	github.com/davecgh/go-spew v1.1.1 // indirect
-	github.com/decred/dcrd/dcrec/secp256k1/v4 v4.0.1 // indirect
+	github.com/decred/dcrd/dcrec/secp256k1/v4 v4.3.0 // indirect
 	github.com/holiman/uint256 v1.2.3 // indirect
 	github.com/pmezard/go-difflib v1.0.0 // indirect
 	golang.org/x/sys v0.13.0 // indirect

--- a/coins/harmony/go.mod
+++ b/coins/harmony/go.mod
@@ -3,7 +3,7 @@ module github.com/okx/go-wallet-sdk/coins/harmony
 go 1.19
 
 require (
-	github.com/btcsuite/btcd/btcec/v2 v2.3.2
+	github.com/btcsuite/btcd/btcec/v2 v2.3.4
 	github.com/btcsuite/btcd/btcutil v1.1.3
 	github.com/okx/go-wallet-sdk/coins/ethereum v0.0.2
 	github.com/stretchr/testify v1.8.1
@@ -11,7 +11,7 @@ require (
 
 require (
 	github.com/davecgh/go-spew v1.1.1 // indirect
-	github.com/decred/dcrd/dcrec/secp256k1/v4 v4.0.1 // indirect
+	github.com/decred/dcrd/dcrec/secp256k1/v4 v4.3.0 // indirect
 	github.com/ethereum/go-ethereum v1.12.2 // indirect
 	github.com/go-stack/stack v1.8.1 // indirect
 	github.com/holiman/uint256 v1.2.3 // indirect

--- a/coins/kaspa/go.mod
+++ b/coins/kaspa/go.mod
@@ -3,7 +3,7 @@ module github.com/okx/go-wallet-sdk/coins/kaspa
 go 1.19
 
 require (
-	github.com/btcsuite/btcd/btcec/v2 v2.3.2
+	github.com/btcsuite/btcd/btcec/v2 v2.3.4
 	github.com/kaspanet/go-secp256k1 v0.0.7
 	github.com/kaspanet/kaspad v0.12.14
 	github.com/stretchr/testify v1.8.4
@@ -13,8 +13,8 @@ require (
 require (
 	github.com/btcsuite/btcd/chaincfg/chainhash v1.0.1 // indirect
 	github.com/davecgh/go-spew v1.1.1 // indirect
-	github.com/decred/dcrd/crypto/blake256 v1.0.0 // indirect
-	github.com/decred/dcrd/dcrec/secp256k1/v4 v4.0.1 // indirect
+	github.com/decred/dcrd/crypto/blake256 v1.0.1 // indirect
+	github.com/decred/dcrd/dcrec/secp256k1/v4 v4.3.0 // indirect
 	github.com/golang/protobuf v1.5.3 // indirect
 	github.com/golang/snappy v0.0.4 // indirect
 	github.com/jrick/logrotate v1.0.0 // indirect

--- a/coins/nervos/crypto/secp256k1.go
+++ b/coins/nervos/crypto/secp256k1.go
@@ -7,6 +7,7 @@ import (
 	"encoding/hex"
 	"errors"
 	"fmt"
+
 	"github.com/btcsuite/btcd/btcec/v2"
 	btcec_ecdsa "github.com/btcsuite/btcd/btcec/v2/ecdsa"
 	"github.com/decred/dcrd/dcrec/secp256k1/v4"
@@ -40,10 +41,7 @@ func ZeroBytes(bytes []byte) {
 }
 
 func SignAsRecoverable(value []byte, prvKey *btcec.PrivateKey) *SignatureData {
-	sig, err := btcec_ecdsa.SignCompact(prvKey, value, false)
-	if err != nil {
-		return nil
-	}
+	sig := btcec_ecdsa.SignCompact(prvKey, value, false)
 	V := sig[0]
 	R := sig[1:33]
 	S := sig[33:65]

--- a/coins/nervos/go.mod
+++ b/coins/nervos/go.mod
@@ -3,13 +3,13 @@ module github.com/okx/go-wallet-sdk/coins/nervos
 go 1.19
 
 require (
-	github.com/btcsuite/btcd/btcec/v2 v2.3.2
+	github.com/btcsuite/btcd/btcec/v2 v2.3.4
 	github.com/btcsuite/btcd/btcutil v1.1.3
 	github.com/dchest/blake2b v1.0.0
 )
 
 require (
-	github.com/decred/dcrd/dcrec/secp256k1/v4 v4.0.1
+	github.com/decred/dcrd/dcrec/secp256k1/v4 v4.3.0
 	github.com/stretchr/testify v1.8.0
 )
 

--- a/coins/nostrassets/go.mod
+++ b/coins/nostrassets/go.mod
@@ -3,9 +3,9 @@ module github.com/okx/go-wallet-sdk/coins/nostrassets
 go 1.19
 
 require (
-	github.com/btcsuite/btcd/btcec/v2 v2.3.2
+	github.com/btcsuite/btcd/btcec/v2 v2.3.4
 	github.com/btcsuite/btcd/btcutil v1.1.3
-	github.com/decred/dcrd/dcrec/secp256k1/v4 v4.0.1
+	github.com/decred/dcrd/dcrec/secp256k1/v4 v4.3.0
 	github.com/okx/go-wallet-sdk/util v0.0.1
 	github.com/stretchr/testify v1.8.0
 )
@@ -13,7 +13,7 @@ require (
 require (
 	github.com/btcsuite/btcd/chaincfg/chainhash v1.1.0 // indirect
 	github.com/davecgh/go-spew v1.1.1 // indirect
-	github.com/decred/dcrd/crypto/blake256 v1.0.0 // indirect
+	github.com/decred/dcrd/crypto/blake256 v1.0.1 // indirect
 	github.com/pmezard/go-difflib v1.0.0 // indirect
 	gopkg.in/yaml.v3 v3.0.1 // indirect
 )

--- a/coins/oracle/vrf/go.mod
+++ b/coins/oracle/vrf/go.mod
@@ -3,7 +3,7 @@ module github.com/okx/go-wallet-sdk/coins/oracle/vrf
 go 1.19
 
 require (
-	github.com/btcsuite/btcd/btcec/v2 v2.3.2
+	github.com/btcsuite/btcd/btcec/v2 v2.3.4
 	github.com/ethereum/go-ethereum v1.13.4
 	github.com/okx/go-wallet-sdk/crypto v0.0.2-0.20231110114921-d140b1f1a6cb
 	github.com/shopspring/decimal v1.3.1
@@ -14,7 +14,7 @@ require (
 require (
 	github.com/btcsuite/btcd v0.22.3 // indirect
 	github.com/davecgh/go-spew v1.1.1 // indirect
-	github.com/decred/dcrd/dcrec/secp256k1/v4 v4.2.0 // indirect
+	github.com/decred/dcrd/dcrec/secp256k1/v4 v4.3.0 // indirect
 	github.com/okx/go-wallet-sdk/util v0.0.1 // indirect
 	github.com/pmezard/go-difflib v1.0.0 // indirect
 	golang.org/x/crypto v0.15.0 // indirect

--- a/coins/stacks/go.mod
+++ b/coins/stacks/go.mod
@@ -3,8 +3,8 @@ module github.com/okx/go-wallet-sdk/coins/stacks
 go 1.19
 
 require (
-	github.com/btcsuite/btcd/btcec/v2 v2.3.2
-	github.com/decred/dcrd/dcrec/secp256k1/v4 v4.2.0
+	github.com/btcsuite/btcd/btcec/v2 v2.3.4
+	github.com/decred/dcrd/dcrec/secp256k1/v4 v4.3.0
 	github.com/okx/go-wallet-sdk/crypto v0.0.1
 	github.com/stretchr/testify v1.8.4
 	golang.org/x/crypto v0.12.0

--- a/coins/stacks/signer.go
+++ b/coins/stacks/signer.go
@@ -10,11 +10,12 @@ import (
 	"encoding/json"
 	"errors"
 	"fmt"
-	"github.com/btcsuite/btcd/btcec/v2"
-	ec "github.com/btcsuite/btcd/btcec/v2/ecdsa"
 	"math/big"
 	"strconv"
 	"strings"
+
+	"github.com/btcsuite/btcd/btcec/v2"
+	ec "github.com/btcsuite/btcd/btcec/v2/ecdsa"
 )
 
 func addressFromVersionHash(version uint64, hash string) *Signer {
@@ -129,10 +130,7 @@ func sign(privateKey, txHex string) (*ec.Signature, *uint8, error) {
 	}
 	sig := ec.Sign(privKey, txBytes)
 
-	sig2, err := ec.SignCompact(privKey, txBytes, false)
-	if err != nil {
-		return nil, nil, err
-	}
+	sig2 := ec.SignCompact(privKey, txBytes, false)
 	v := sig2[0] - 27
 	copy(sig2, sig2[1:])
 	sig2[64] = v

--- a/coins/tron/go.mod
+++ b/coins/tron/go.mod
@@ -3,7 +3,7 @@ module github.com/okx/go-wallet-sdk/coins/tron
 go 1.19
 
 require (
-	github.com/btcsuite/btcd/btcec/v2 v2.3.2
+	github.com/btcsuite/btcd/btcec/v2 v2.3.4
 	github.com/golang/protobuf v1.5.3
 	github.com/okx/go-wallet-sdk/crypto v0.0.1
 	github.com/okx/go-wallet-sdk/util v0.0.1
@@ -14,7 +14,7 @@ require (
 require (
 	github.com/btcsuite/btcutil v1.0.2 // indirect
 	github.com/davecgh/go-spew v1.1.1 // indirect
-	github.com/decred/dcrd/dcrec/secp256k1/v4 v4.0.1 // indirect
+	github.com/decred/dcrd/dcrec/secp256k1/v4 v4.3.0 // indirect
 	github.com/pmezard/go-difflib v1.0.0 // indirect
 	golang.org/x/sys v0.11.0 // indirect
 	google.golang.org/protobuf v1.26.0 // indirect

--- a/coins/tron/tron.go
+++ b/coins/tron/tron.go
@@ -4,9 +4,10 @@ import (
 	"crypto/sha256"
 	"encoding/hex"
 	"fmt"
+	"math/big"
+
 	"github.com/btcsuite/btcd/btcec/v2"
 	"golang.org/x/crypto/sha3"
-	"math/big"
 
 	"github.com/btcsuite/btcd/btcec/v2/ecdsa"
 	"github.com/golang/protobuf/proto"
@@ -92,10 +93,7 @@ func Sign(data string, privateKey *btcec.PrivateKey) (string, error) {
 	if err != nil {
 		return "", err
 	}
-	signature, err := ecdsa.SignCompact(privateKey, hash, false)
-	if err != nil {
-		return "", err
-	}
+	signature := ecdsa.SignCompact(privateKey, hash, false)
 	return hex.EncodeToString(signature), nil
 }
 

--- a/coins/zil/go.mod
+++ b/coins/zil/go.mod
@@ -3,7 +3,7 @@ module github.com/okx/go-wallet-sdk/coins/zil
 go 1.19
 
 require (
-	github.com/btcsuite/btcd/btcec/v2 v2.3.2
+	github.com/btcsuite/btcd/btcec/v2 v2.3.4
 	github.com/btcsuite/btcd/btcutil v1.1.3
 	github.com/stretchr/testify v1.8.4
 	google.golang.org/protobuf v1.31.0
@@ -11,7 +11,7 @@ require (
 
 require (
 	github.com/davecgh/go-spew v1.1.1 // indirect
-	github.com/decred/dcrd/dcrec/secp256k1/v4 v4.0.1
+	github.com/decred/dcrd/dcrec/secp256k1/v4 v4.3.0
 	github.com/pmezard/go-difflib v1.0.0 // indirect
 	gopkg.in/yaml.v3 v3.0.1 // indirect
 )

--- a/coins/zkspace/go.mod
+++ b/coins/zkspace/go.mod
@@ -9,12 +9,12 @@ require (
 
 require (
 	github.com/bits-and-blooms/bitset v1.11.0 // indirect
-	github.com/btcsuite/btcd/btcec/v2 v2.3.2 // indirect
+	github.com/btcsuite/btcd/btcec/v2 v2.3.4 // indirect
 	github.com/consensys/bavard v0.1.13 // indirect
 	github.com/consensys/gnark-crypto v0.12.1 // indirect
 	github.com/crate-crypto/go-kzg-4844 v0.7.0 // indirect
 	github.com/davecgh/go-spew v1.1.1 // indirect
-	github.com/decred/dcrd/dcrec/secp256k1/v4 v4.2.0 // indirect
+	github.com/decred/dcrd/dcrec/secp256k1/v4 v4.3.0 // indirect
 	github.com/ethereum/c-kzg-4844/bindings/go v0.0.0-20230126171313-363c7d7593b4 // indirect
 	github.com/ethereum/go-ethereum v1.13.4 // indirect
 	github.com/go-stack/stack v1.8.1 // indirect

--- a/coins/zksync/go.mod
+++ b/coins/zksync/go.mod
@@ -3,7 +3,7 @@ module github.com/okx/go-wallet-sdk/coins/zksync
 go 1.19
 
 require (
-	github.com/btcsuite/btcd/btcec/v2 v2.3.2
+	github.com/btcsuite/btcd/btcec/v2 v2.3.4
 	github.com/okx/go-wallet-sdk/coins/ethereum v0.0.2
 	github.com/stretchr/testify v1.8.1
 	golang.org/x/crypto v0.15.0
@@ -11,7 +11,7 @@ require (
 
 require (
 	github.com/davecgh/go-spew v1.1.1 // indirect
-	github.com/decred/dcrd/dcrec/secp256k1/v4 v4.0.1 // indirect
+	github.com/decred/dcrd/dcrec/secp256k1/v4 v4.3.0 // indirect
 	github.com/ethereum/go-ethereum v1.12.2 // indirect
 	github.com/go-stack/stack v1.8.1 // indirect
 	github.com/holiman/uint256 v1.2.3 // indirect

--- a/crypto/go.mod
+++ b/crypto/go.mod
@@ -4,7 +4,7 @@ go 1.19
 
 require (
 	github.com/btcsuite/btcd v0.22.3
-	github.com/btcsuite/btcd/btcec/v2 v2.2.0
+	github.com/btcsuite/btcd/btcec/v2 v2.3.4
 	github.com/btcsuite/btcd/btcutil v1.1.1
 	github.com/btcsuite/btcutil v1.0.3-0.20201208143702-a53e38424cce
 	github.com/ethereum/go-ethereum v1.13.4
@@ -19,6 +19,6 @@ require (
 	github.com/FactomProject/basen v0.0.0-20150613233007-fe3947df716e // indirect
 	github.com/FactomProject/btcutilecc v0.0.0-20130527213604-d3a63a5752ec // indirect
 	github.com/btcsuite/btcd/chaincfg/chainhash v1.0.2 // indirect
-	github.com/decred/dcrd/dcrec/secp256k1/v4 v4.0.1 // indirect
+	github.com/decred/dcrd/dcrec/secp256k1/v4 v4.3.0 // indirect
 	golang.org/x/sys v0.14.0 // indirect
 )

--- a/example/go.mod
+++ b/example/go.mod
@@ -4,8 +4,8 @@ go 1.19
 
 require (
 	github.com/btcsuite/btcd v0.22.3
-	github.com/btcsuite/btcd/btcec/v2 v2.3.2
-	github.com/decred/dcrd/dcrec/secp256k1/v4 v4.0.1
+	github.com/btcsuite/btcd/btcec/v2 v2.3.4
+	github.com/decred/dcrd/dcrec/secp256k1/v4 v4.3.0
 	github.com/ethereum/go-ethereum v1.13.4
 	github.com/okx/go-wallet-sdk/coins/ethereum v0.0.3
 	github.com/okx/go-wallet-sdk/crypto v0.0.2


### PR DESCRIPTION
`btcec` makes a breaking change to make `ecdsa.SignCompact` infallible.