### PR TITLE
bitcoin,tron: update btcec to same version

### DIFF
--- a/coins/bitcoin/go.mod
+++ b/coins/bitcoin/go.mod
@@ -1,10 +1,10 @@
 module github.com/okx/go-wallet-sdk/coins/bitcoin
 
-go 1.19
+go 1.22
 
 require (
 	github.com/btcsuite/btcd v0.23.4
-	github.com/btcsuite/btcd/btcec/v2 v2.3.2
+	github.com/btcsuite/btcd/btcec/v2 v2.3.6
 	github.com/btcsuite/btcd/btcutil v1.1.3
 	github.com/btcsuite/btcd/btcutil/psbt v1.1.8
 	github.com/btcsuite/btcd/chaincfg/chainhash v1.0.2
@@ -22,8 +22,8 @@ require (
 	github.com/consensys/gnark-crypto v0.12.1 // indirect
 	github.com/crate-crypto/go-kzg-4844 v0.3.0 // indirect
 	github.com/davecgh/go-spew v1.1.1 // indirect
-	github.com/decred/dcrd/crypto/blake256 v1.0.0 // indirect
-	github.com/decred/dcrd/dcrec/secp256k1/v4 v4.0.1 // indirect
+	github.com/decred/dcrd/crypto/blake256 v1.1.0 // indirect
+	github.com/decred/dcrd/dcrec/secp256k1/v4 v4.4.0 // indirect
 	github.com/ethereum/c-kzg-4844 v0.3.1 // indirect
 	github.com/go-stack/stack v1.8.1 // indirect
 	github.com/holiman/uint256 v1.2.3 // indirect

--- a/coins/bitcoin/message.go
+++ b/coins/bitcoin/message.go
@@ -540,10 +540,7 @@ func SignMessage(wif string, prefix, message string) (string, error) {
 	if err != nil {
 		return "", err
 	}
-	sig, err := ecdsa.SignCompact(w.PrivKey, messageHash, w.CompressPubKey)
-	if err != nil {
-		return "", err
-	}
+	sig := ecdsa.SignCompact(w.PrivKey, messageHash, w.CompressPubKey)
 	return base64.StdEncoding.EncodeToString(sig), nil
 }
 

--- a/coins/tron/go.mod
+++ b/coins/tron/go.mod
@@ -1,9 +1,9 @@
 module github.com/okx/go-wallet-sdk/coins/tron
 
-go 1.19
+go 1.22
 
 require (
-	github.com/btcsuite/btcd/btcec/v2 v2.3.4
+	github.com/btcsuite/btcd/btcec/v2 v2.3.6
 	github.com/golang/protobuf v1.5.3
 	github.com/okx/go-wallet-sdk/crypto v0.0.1
 	github.com/okx/go-wallet-sdk/util v0.0.1
@@ -14,7 +14,7 @@ require (
 require (
 	github.com/btcsuite/btcutil v1.0.2 // indirect
 	github.com/davecgh/go-spew v1.1.1 // indirect
-	github.com/decred/dcrd/dcrec/secp256k1/v4 v4.0.1 // indirect
+	github.com/decred/dcrd/dcrec/secp256k1/v4 v4.4.0 // indirect
 	github.com/pmezard/go-difflib v1.0.0 // indirect
 	golang.org/x/sys v0.11.0 // indirect
 	google.golang.org/protobuf v1.26.0 // indirect


### PR DESCRIPTION
Currently, `coins/bitcoin` depends btcec@v2.3.2 and `coins/tron` depends on btcec@2.3.4
this will make conflicts if developer import both `coins/bitcoin` and `coins/tron` pakcage.